### PR TITLE
Add grouping for common updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,3 +13,8 @@ updates:
       timezone: 'Europe/London'
     commit-message:
       prefix: '[dependabot:actions] '
+    groups:
+      regular-updates: # Group everything except major version updates and security vulnerabilities
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Tweaking the dependabot settings to minimise the number of PRs each week. Major updates won't be batched if they happen, and security updates will always be a single PR