### PR TITLE
Add ECR repo to the start of tag overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ In order to give a repository the AWS permissions required to run this action, t
 | `dockerfile`         | The name of the dockerfile to be built.                                                                                                                             | No       | `Dockerfile`                                    |
 | `build-args`         | List of build-time variables.                                                                                                                                       | No       |                                                 |
 | `prod_image`         | Mark the image as a production image. Adds `latest` tag. When false, adds `dev_` to hash tag.                                                                       | No       | false                                           |
-| `tags_override`      | Override the default tags. This will replace ALL of the default tags                                                                                                | No       | See default tags above                          |
+| `tags_override`      | Override the default tags. This will replace ALL of the default tags. Must be a comma separated list with no spaces                                                 | No       | See default tags above                          |
 
 The user associated with the `aws_access_key` must have permission to push, update and read the private repository in question.
 

--- a/action.yaml
+++ b/action.yaml
@@ -119,7 +119,15 @@ runs:
         if [[ "${{ inputs.tags_override }}" == "" ]] ; then
           echo  "tags=${{ steps.ecr-login.outputs.registry }}/${{ inputs.repository_name }}:${{ steps.dev-tag.outputs.tag }}${{ github.sha }},${{ steps.ecr-login.outputs.registry }}/${{ inputs.repository_name }}:${{ steps.branch-name.outputs.name }},${{ steps.latest-tag.outputs.tag }}" >> $GITHUB_OUTPUT
         else
-          echo "tags=${{ inputs.tags_override }}" >> $GITHUB_OUTPUT
+          tags_override="${{ inputs.tags_override }}"
+          IFS=$','; split=($tags_override); unset IFS;
+
+          full_tags=""
+          for tag in "${split[@]}"
+          do
+            full_tags+="${{ steps.ecr-login.outputs.registry }}/${{ inputs.repository_name }}:$tag,"
+          done
+          echo "tags=$full_tags" >> $GITHUB_OUTPUT
         fi
 
     - uses: actions/checkout@v4

--- a/action.yaml
+++ b/action.yaml
@@ -58,9 +58,9 @@ runs:
       shell: bash
       run: |
         if [[ "${{ inputs.multiarch_build }}" == "enabled" ]] ; then
-          echo "multiarch=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
+          echo "multiarch=linux/amd64,linux/arm64" | tee -a $GITHUB_OUTPUT
         elif [[ "${{ inputs.multiarch_build }}" == "disabled" ]] ; then
-          echo "multiarch=linux/amd64" >> $GITHUB_OUTPUT
+          echo "multiarch=linux/amd64" | tee -a $GITHUB_OUTPUT
         else
           echo "Input `multiarch_build` not set correctly. Options are 'enabled' or 'disabled'"
           exit 1
@@ -84,16 +84,16 @@ runs:
       shell: bash
       run: |
         branch=${{ github.head_ref || github.ref_name }}
-        echo "name=${branch//\//-}" >> $GITHUB_OUTPUT
+        echo "name=${branch//\//-}" | tee -a $GITHUB_OUTPUT
 
     - name: Configure latest tag
       id: latest-tag
       shell: bash
       run: |
         if [[ "${{ inputs.prod_image }}" == "true" ]] ; then
-          echo "tag=${{ steps.ecr-login.outputs.registry }}/${{ inputs.repository_name }}:latest" >> $GITHUB_OUTPUT
+          echo "tag=${{ steps.ecr-login.outputs.registry }}/${{ inputs.repository_name }}:latest" | tee -a $GITHUB_OUTPUT
         elif [[ "${{ inputs.prod_image }}" == "false" ]] ; then
-          echo "tag=" >> $GITHUB_OUTPUT
+          echo "tag=" | tee -a $GITHUB_OUTPUT
         else
           echo "Input `prod_image` not set correctly. Options are 'true' or 'false'"
           exit 1
@@ -104,9 +104,9 @@ runs:
       shell: bash
       run: |
         if [[ "${{ inputs.prod_image }}" == "false" ]] ; then
-          echo "tag=dev_" >> $GITHUB_OUTPUT
+          echo "tag=dev_" | tee -a $GITHUB_OUTPUT
         elif [[ "${{ inputs.prod_image }}" == "true" ]] ; then
-          echo "tag=" >> $GITHUB_OUTPUT
+          echo "tag=" | tee -a $GITHUB_OUTPUT
         else
           echo "Input `dev_tag` not set correctly. Options are 'true' or 'false'"
           exit 1
@@ -117,17 +117,9 @@ runs:
       shell: bash
       run: |
         if [[ "${{ inputs.tags_override }}" == "" ]] ; then
-          echo  "tags=${{ steps.ecr-login.outputs.registry }}/${{ inputs.repository_name }}:${{ steps.dev-tag.outputs.tag }}${{ github.sha }},${{ steps.ecr-login.outputs.registry }}/${{ inputs.repository_name }}:${{ steps.branch-name.outputs.name }},${{ steps.latest-tag.outputs.tag }}" >> $GITHUB_OUTPUT
+          echo  "tags=${{ steps.ecr-login.outputs.registry }}/${{ inputs.repository_name }}:${{ steps.dev-tag.outputs.tag }}${{ github.sha }},${{ steps.ecr-login.outputs.registry }}/${{ inputs.repository_name }}:${{ steps.branch-name.outputs.name }},${{ steps.latest-tag.outputs.tag }}" | tee -a $GITHUB_OUTPUT
         else
-          tags_override="${{ inputs.tags_override }}"
-          IFS=$','; split=($tags_override); unset IFS;
-
-          full_tags=""
-          for tag in "${split[@]}"
-          do
-            full_tags+="${{ steps.ecr-login.outputs.registry }}/${{ inputs.repository_name }}:$tag,"
-          done
-          echo "tags=$full_tags" >> $GITHUB_OUTPUT
+          python -c 'print("tags=" + ",".join(f"${{ steps.ecr-login.outputs.registry }}/${{ inputs.repository_name }}:{tag}" for tag in "${{ inputs.tags_override }}".split(",")))' | tee -a $GITHUB_OUTPUT
         fi
 
     - uses: actions/checkout@v4


### PR DESCRIPTION
This lets client code pass a list of simple tags, without having to generate the full ECR tag including the AWS account and repo name.

I've tested this with a local copy of the action: https://github.com/citizensadvice/content-platform-proxy/actions/runs/10493850736

I couldn't find anyone using this parameter already, so hopefully it won't break any existing code. But let me know if there's a different way to approach this.

There may be a nicer way to do this in bash - happy to refactor!